### PR TITLE
修正 無電子發票時 szInvoiceItemTaxType 為定義錯誤

### DIFF
--- a/AllPay.Payment.Integration.php
+++ b/AllPay.Payment.Integration.php
@@ -513,6 +513,7 @@ class AllInOne {
         $szInvoiceItemCount = '';
         $szInvoiceItemWord = '';
         $szInvoiceItemPrice = '';
+        $szInvoiceItemTaxType = '';
         $InvSptr = '|';
         // 檢查資料。
         if (strlen($this->ServiceURL) == 0) {


### PR DESCRIPTION
當設定 InvoiceMark 為 No 的時候
在 910 行會因為 $szInvoiceItemTaxType 未定義而產生錯誤訊息